### PR TITLE
Add tickets sorting

### DIFF
--- a/tap_gorgias/streams.py
+++ b/tap_gorgias/streams.py
@@ -28,7 +28,7 @@ class TicketsStream(GorgiasStream):
     path = "/api/views/{view_id}/items"
     primary_keys = ["id"]
     replication_key = "updated_datetime"
-    is_sorted = True
+    # is_sorted = True
 
     # Link to the next items, if any.
     next_page_token_jsonpath = "$.meta.next_items"


### PR DESCRIPTION
This fixes the problem where the tap would crash for tickets being out of order.

The issue is caused by Gorgias' API returning tickets out of order if they were updated on the same second. This patch ensures the tickets will be handled in order.

This doesn't cover the case if the out-of-order problem happens across a page boundary. However, considering the number of tickets in total, how many are returned on each page, and how rare this problem is anyway, I don't expect that to become an issue. Hopefully Gorgias can fix this problem by then and once that's done, we can remove this patch.