### PR TITLE
Add macros stream

### DIFF
--- a/tap_gorgias/streams.py
+++ b/tap_gorgias/streams.py
@@ -640,3 +640,35 @@ class IntegreationsStream(GorgiasStream):
         th.Property("locked_datetime", th.DateTimeType),
         th.Property("deleted_datetime", th.DateTimeType),
     ).to_dict()
+
+
+class MacrosStream(GorgiasStream):
+    name = "macros"
+    path = "/api/macros"
+    primary_keys = ["id"]
+
+    schema = th.PropertiesList(
+        th.Property("id", th.IntegerType),
+        th.Property("external_id", th.StringType),
+        th.Property("name", th.StringType),
+        th.Property("intent", th.StringType),
+        th.Property("language", th.StringType),
+        th.Property("usage", th.IntegerType),
+        th.Property("actions", th.ArrayType(
+            th.ObjectType(
+                th.Property("arguments", th.ObjectType(
+                    th.Property("body_html", th.StringType),
+                    th.Property("body_text", th.StringType),
+                    th.Property("tags", th.StringType),
+                    additional_properties=True,
+                )),
+                th.Property("description", th.StringType),
+                th.Property("name", th.StringType),
+                th.Property("title", th.StringType),
+                th.Property("type", th.StringType),
+            )
+        )),
+        th.Property("created_datetime", th.DateTimeType),
+        th.Property("updated_datetime", th.DateTimeType),
+        th.Property("uri", th.StringType),
+    ).to_dict()

--- a/tap_gorgias/tap.py
+++ b/tap_gorgias/tap.py
@@ -12,6 +12,7 @@ from tap_gorgias.streams import (
     CustomersStream,
     TicketDetailsStream,
     IntegreationsStream,
+    MacrosStream,
 )
 
 STREAM_TYPES = [
@@ -21,6 +22,7 @@ STREAM_TYPES = [
     CustomersStream,
     TicketDetailsStream,
     IntegreationsStream,
+    MacrosStream,
 ]
 
 


### PR DESCRIPTION
One thing to keep in mind: The parameters of the [MacroAction Object](https://developers.gorgias.com/reference/the-macroaction-object)'s `arguments` property are not documented in Gorgias' docs. I asked question about this: [MacroActions arguments documentation](https://developers.gorgias.com/discuss/667f56fea68c68002926f8ca).

Examining all 284 Perelel macros, however, shows that the only properties actually used in practice are `body_html`, `body_text`, and `tags`, so I added those three to the schema. Just in case other properties are possible, I set `additional_properties` to true.

Other than that, I believe this is ready to go.